### PR TITLE
Fix copyTask filtering out random files

### DIFF
--- a/src/util/copyTask.ts
+++ b/src/util/copyTask.ts
@@ -73,7 +73,7 @@ async function deleteObsolete() {
 	//* Old files, delete
 	await Promise.all(
 		dist
-			.filter((f) => !src.includes(f.replace(config.out, "").split(".")[0]))
+			.filter((f) => !src.includes((f.startsWith(config.out) ? f.replace(config.out, "") : f).split(".")[0]))
 			.map((f) => remove(resolve(config.out, f)))
 	);
 	logger("Deleted obsolete files");


### PR DESCRIPTION
If your filename contains the name of the `out` folder, the copyTask will accidentally try to remove the out folder from the file path while checking for obsolete files, throwing out the file.

For example:
`commands/gen/image/distort.js` has `dist` and when filtering, will be replaced as `commands/gen/image/ort` and being checked against the list of file paths.